### PR TITLE
Added login options to login url

### DIFF
--- a/streamlit_keycloak/frontend/src/Keycloak.svelte
+++ b/streamlit_keycloak/frontend/src/Keycloak.svelte
@@ -25,6 +25,7 @@
 
     const getLoginUrl = (): string => {
         return keycloak.createLoginUrl({
+            ...loginOptions,
             redirectUri: rewritePage('/login.html'),
         })
     }


### PR DESCRIPTION
Regarding my comments on issue:
https://github.com/bleumink/streamlit-keycloak/issues/13

I found the bug, thus the login options must also be included in the login url to allow for using kc_idp_hint and other features from Keycloak.

Best regards.
Hans Erik